### PR TITLE
Update Makefile

### DIFF
--- a/shadowsocks-rust/Makefile
+++ b/shadowsocks-rust/Makefile
@@ -21,7 +21,7 @@ endif
 
 ifeq ($(ARCH),aarch64)
   PKG_SOURCE:=$(PKG_SOURCE_HEADER).aarch64-$(PKG_SOURCE_BODY).$(PKG_SOURCE_FOOTER)
-  PKG_HASH:=a4551b599c0e0adbd395528681c748ac2ad71fd5ca37b39a900a49e767e8cc46
+  PKG_HASH:=8c0d0cd3b614888cd3ffcdf9e007ba8697aa6331f8433c90b0a3b2bc3eb37e8b
 else ifeq ($(ARCH),arm)
   # Referred to golang/golang-values.mk
   ARM_CPU_FEATURES:=$(word 2,$(subst +,$(space),$(call qstrip,$(CONFIG_CPU_TYPE))))


### PR DESCRIPTION
更新 Makefile 里 aarch64 的 hash

https://github.com/shadowsocks/shadowsocks-rust/releases/download/v1.20.1/shadowsocks-v1.20.1.aarch64-unknown-linux-musl.tar.xz.sha256

![5678](https://github.com/kenzok8/small/assets/20328741/6d35ea6e-c264-4223-a052-00723c2dec20)
