### PR TITLE
fix: resolve luci-app-fchomo recursive dependency

### DIFF
--- a/clashoo/Makefile
+++ b/clashoo/Makefile
@@ -36,7 +36,7 @@ define Package/clashoo
   CATEGORY:=Network
   TITLE:=Clashoo (Mihomo)
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +yq +firewall4 +ip-full +coreutils-nohup +coreutils-timeout +kmod-inet-diag +kmod-nft-socket +kmod-nft-tproxy +kmod-tun +kmod-dummy +unzip
-  PROVIDES:=mihomo clash-meta
+  PROVIDES:=clash-meta
 endef
 
 define Package/clashoo/description

--- a/mihomo/Makefile
+++ b/mihomo/Makefile
@@ -37,7 +37,6 @@ define Package/mihomo
   TITLE:=Another Mihomo Kernel.
   URL:=https://wiki.metacubex.one
   DEPENDS:=$(GO_ARCH_DEPENDS)
-  PROVIDES:=mihomo
   ALTERNATIVES:=\
     100:/usr/bin/mihomo:/usr/libexec/mihomo-core
   USERID:=mihomo=7890:mihomo=7890


### PR DESCRIPTION
## Summary

- stop `clashoo` from advertising itself as a generic `mihomo` provider
- remove the redundant self-`PROVIDES` declaration from the `mihomo` package
- keep the `clash-meta` virtual capability unchanged

## Problem

`luci-app-fchomo` selects `+mihomo`, while both the actual `mihomo` package and `clashoo` advertise that capability. OpenWrt expands multiple virtual providers into a conditional Kconfig selection which references the consuming package, resulting in:

```
recursive dependency detected!
symbol PACKAGE_luci-app-fchomo depends on PACKAGE_luci-app-fchomo
```

After this change, `+mihomo` resolves to the dedicated `mihomo` package. `luci-app-clashoo` is unaffected because it directly depends on `clashoo`.

## Validation

- `git diff --check`
- verified there are no remaining explicit `mihomo` providers in this feed
- verified `luci-app-fchomo` and `nikki` continue to depend on `+mihomo`